### PR TITLE
feature:video download butbuton

### DIFF
--- a/front/src/app/hooks/useTextAnalysis.ts
+++ b/front/src/app/hooks/useTextAnalysis.ts
@@ -240,6 +240,49 @@ export const useVideoGeneration = () => {
     }
 
     /**
+     * ⚠️ テスト用（Issue#56）
+     * 
+     * 既存の動画を読み込む
+     * 
+     * 目的：
+     * - バックエンドで新規に動画を生成せずにダウンロード機能をテストする
+     * 
+     * 削除方法：
+     * 1. この関数全体を削除
+     * 2. return文から `loadExistingVideo` を削除
+     * 3. VideoGenerationFlow.tsx から呼び出しを削除
+     */
+    const loadExistingVideo = async (videoId: string, promptText: string = '既存の動画') => {
+        try {
+            setIsGenerating(true)
+            setError(null)
+
+            const videoUrl = await replaceVideoUrl(videoId)
+            
+            const prompt: VideoGenerationPrompt = {
+                prompt: promptText,
+                originalText: promptText,
+            }
+
+            const loadedResult: VideoResult = {
+                videoId,
+                videoUrl,
+                prompt,
+                generatedAt: new Date(),
+            }
+
+            setPrompt(prompt)
+            setResult(loadedResult)
+            return loadedResult
+        } catch (err) {
+            setHandledError(err, '動画の読み込み中にエラーが発生しました')
+            throw err
+        } finally {
+            setIsGenerating(false)
+        }
+    }
+
+    /**
      * 結果をクリア
      */
     const clearResult = () => {
@@ -263,6 +306,7 @@ export const useVideoGeneration = () => {
         generatePrompt,
         generateVideo,
         editVideo,
+        loadExistingVideo, // ⚠️ テスト用（Issue#56）
         clearResult,
     }
 }

--- a/front/src/components/VideoGenerationFlow.tsx
+++ b/front/src/components/VideoGenerationFlow.tsx
@@ -5,16 +5,25 @@ import { Generating } from './generating/Generating'
 import { Landing } from './landing/Landing'
 import { Result } from './result/Result'
 
+// ⚠️ テスト用import（Issue#56）
+// この import を削除すると、テスト用ボタンが表示されなくなります
+import { TestVideoLoader } from './__test_utils__/TestVideoLoader'
+
 /**
  * Presentation層: 状態管理
  * 3つの状態を管理: ランディング、動画生成中、リザルト
  * 状態遷移とルーティングを担当
  */
 export function VideoGenerationFlow() {
-    const { isGenerating, result, error, startVideoGeneration, editVideo, clearResult } = useVideoGeneration()
+    const { isGenerating, result, error, startVideoGeneration, editVideo, loadExistingVideo, clearResult } = useVideoGeneration()
 
     const handleLandingSubmit = async (text: string, videoPrompt?: string) => {
         await startVideoGeneration(text, videoPrompt)
+    }
+
+    // ⚠️ テスト用（Issue#56）
+    const handleLoadExistingVideo = async (videoId: string, promptText: string) => {
+        await loadExistingVideo(videoId, promptText)
     }
 
     const isLanding = !isGenerating && !result
@@ -25,7 +34,19 @@ export function VideoGenerationFlow() {
     return (
         <div className={`h-full flex flex-col w-full min-w-0 ${containerOverflowClass}`}>
             {/* 状態1: ランディング（テキスト入力） */}
-            {isLanding && <Landing onSubmit={handleLandingSubmit} isGenerating={isGenerating} error={error} />}
+            {isLanding && (
+                <Landing 
+                    onSubmit={handleLandingSubmit} 
+                    isGenerating={isGenerating} 
+                    error={error}
+                >
+                    {/* ⚠️ テスト用（Issue#56） */}
+                    <TestVideoLoader 
+                        onLoadVideo={handleLoadExistingVideo}
+                        isLoading={isGenerating}
+                    />
+                </Landing>
+            )}
 
             {/* 状態2: 動画生成中 */}
             {isGeneratingScreen && <Generating />}

--- a/front/src/components/__test_utils__/TestVideoLoader.tsx
+++ b/front/src/components/__test_utils__/TestVideoLoader.tsx
@@ -1,0 +1,58 @@
+/**
+ * ⚠️ テスト用コンポーネント ⚠️
+ * 
+ * このファイルは動画ダウンロード機能のレビュー・動作確認のための一時的なものです。
+ * レビュー完了後、このファイルごと削除してください。
+ * 
+ * 目的：
+ * - 既存の動画を読み込んでダウンロード機能をテストする
+ * - バックエンドで新規に動画を生成せずに動作確認できるようにする
+ * 
+ * 削除時の影響：
+ * - このファイルを削除しても本番コードには影響しません
+ * - VideoGenerationFlow.tsx から import を削除するだけでOK
+ */
+
+'use client'
+
+interface TestVideoLoaderProps {
+    onLoadVideo: (videoId: string, promptText: string) => Promise<void>
+    isLoading: boolean
+}
+
+/**
+ * テスト用：既存動画読み込みボタン
+ */
+export function TestVideoLoader({ onLoadVideo, isLoading }: TestVideoLoaderProps) {
+    // ⚠️ テスト用の動画ID（自分の環境の動画IDに変更してください）
+    const TEST_VIDEO_ID = '0ad1f000-abcd-468c-bd20-2c3190102d5e'
+    const TEST_PROMPT = '単位円と三角関数のデモンストレーション'
+
+    const handleClick = async () => {
+        await onLoadVideo(TEST_VIDEO_ID, TEST_PROMPT)
+    }
+
+    return (
+        <div className="mb-3 p-3 bg-yellow-50 border-2 border-yellow-300 rounded">
+            <div className="flex items-center gap-2 mb-2">
+                <span className="text-lg">⚠️</span>
+                <p className="text-xs font-semibold text-yellow-800">テスト用機能</p>
+            </div>
+            <p className="text-xs text-gray-600 mb-2">
+                既存の動画を読み込んでダウンロード機能をテストします
+            </p>
+            <p className="text-xs text-gray-500 mb-2">
+                動画ID: <code className="bg-gray-100 px-1 rounded">{TEST_VIDEO_ID}</code>
+            </p>
+            <button
+                type="button"
+                onClick={handleClick}
+                disabled={isLoading}
+                className="px-4 py-2 bg-yellow-600 text-white text-sm rounded hover:bg-yellow-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+            >
+                {isLoading ? '読み込み中...' : '動画を読み込む'}
+            </button>
+        </div>
+    )
+}
+

--- a/front/src/components/landing/Landing.tsx
+++ b/front/src/components/landing/Landing.tsx
@@ -6,12 +6,13 @@ interface LandingProps {
     onSubmit: (text: string, videoPrompt?: string) => Promise<void>
     isGenerating: boolean
     error: string | null
+    children?: React.ReactNode // テスト用コンポーネント挿入用
 }
 
 /**
  * Presentation層: ランディングページ全体
  */
-export function Landing({ onSubmit, isGenerating, error }: LandingProps) {
+export function Landing({ onSubmit, isGenerating, error, children }: LandingProps) {
     return (
         <div className="flex flex-col h-full min-w-0">
             {/* エラー表示 */}
@@ -21,6 +22,9 @@ export function Landing({ onSubmit, isGenerating, error }: LandingProps) {
                     <p className="text-sm text-red-700 mt-1">{error}</p>
                 </div>
             )}
+
+            {/* テスト用コンポーネント挿入スロット */}
+            {children}
 
             {/* テキスト入力フォーム（flex-1で残りスペース占有） */}
             <div className="flex-1 min-h-0 overflow-hidden">

--- a/front/src/components/result/Result.tsx
+++ b/front/src/components/result/Result.tsx
@@ -26,6 +26,15 @@ export function Result({ result, isGenerating, onEdit, onReset }: ResultProps) {
         setShowEditPanel(false)
     }
 
+    const handleDownload = () => {
+        const a = document.createElement('a')
+        a.href = result.videoUrl
+        a.download = `${result.videoId}.mp4`
+        document.body.appendChild(a)
+        a.click()
+        document.body.removeChild(a)
+    }
+
     return (
         <div className="flex flex-col h-full">
             {/* ヘッダー */}
@@ -49,8 +58,17 @@ export function Result({ result, isGenerating, onEdit, onReset }: ResultProps) {
             {/* メインコンテンツ: 2カラムレイアウト */}
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0 min-w-0">
                 {/* 左側: 動画プレイヤー（メイン） */}
-                <div className="lg:col-span-2 flex flex-col min-h-0 min-w-0 w-full">
+                <div className="lg:col-span-2 flex flex-col min-h-0 min-w-0 w-full gap-2">
                     <VideoPlayer videoUrl={result.videoUrl} />
+                    
+                    {/* 動画ダウンロードボタン */}
+                    <button
+                        type="button"
+                        onClick={handleDownload}
+                        className="w-full py-2 px-4 bg-gray-100 hover:bg-gray-200 text-gray-800 text-sm rounded"
+                    >
+                        動画をダウンロード
+                    </button>
                 </div>
 
                 {/* 右側: 編集エリア */}


### PR DESCRIPTION
## issue番号
 #56

## やったこと

### ✅ メイン機能（Issue要件）

- `/result`画面に**動画ダウンロードボタン**を追加
  - 動画プレイヤーの真下に配置（シンプル・機能優先のデザイン）
  - ボタンクリックで動画（mp4）がダウンロードされる
  - ファイル名: `{videoId}.mp4`
- **変更ファイル**: `front/src/components/result/Result.tsx`

### 🧪 テスト用機能（レビュー後削除してもいい）
- 既存の動画を読み込んでダウンロード機能をテストできる仕組みテスト用を追加しました
- テスト専用ディレクトリ `front/src/components/__test_utils__/` を作成した
- **目的**: バックエンドで新規に動画生成（10〜20分）せず、レビュアーが簡単に動作確認できるようにする

### 📸 スクリーンショット

- [x] ダウンロードボタンの位置（動画プレイヤーの下）
<img width="1251" height="779" alt="image" src="https://github.com/user-attachments/assets/4e7c6fda-4512-45a0-82a6-2e86d902635b" />

- [x] テスト用ボタン（黄色のボックス）
<img width="1267" height="892" alt="スクリーンショット 2025-10-30 16 45 54" src="https://github.com/user-attachments/assets/33267efa-df40-41ff-9b57-4864bd528c93" />
---


## 動作確認方法

### ⚠️ 事前準備

レビュー・動作確認には**既存の動画ファイルが必要**なので、以下を実施してください：

1. 適当なmp4ファイルを以下のパスに配置
   ```bash
   mkdir -p back/media/videos/0ad1f000-abcd-468c-bd20-2c3190102d5e/480p15/
   # 任意のmp4ファイルを GeneratedScene.mp4 として配置
   cp /path/to/sample.mp4 back/media/videos/0ad1f000-abcd-468c-bd20-2c3190102d5e/480p15/GeneratedScene.mp4
   ```

## とくに見て欲しいところ

**ファイル**: `front/src/components/result/Result.tsx`

- **29-36行目**: `handleDownload` 関数
  - とりあえず機能があることが重要なので、フロントで表示されるmp4をそのままダウンロードする仕組みになっています
  - 圧縮などの加工はしていないのでファイルサイズはデカくなりそう

- **64-71行目**: ダウンロードボタンUI
  - 機能があることが重要なので、装飾やレイアウトなどの事項は一旦検討せずボタンを適当な一に配置しました


### 3. テスト用コードのマーキング
以下のファイルに `⚠️ テスト用（Issue#56）` のマークがあるところはテスト用のコードなので、適宜削除しても構いません
- `front/src/components/VideoGenerationFlow.tsx` (8-10, 24-27, 43-47行目)
- `front/src/components/landing/Landing.tsx` (9, 27行目)
- `front/src/app/hooks/useTextAnalysis.ts` (242-283, 309行目)

