### PR TITLE
refactor/スマホ用画面レイアウトを構築

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -3,7 +3,7 @@ import { VideoGenerationFlow } from '@/components/VideoGenerationFlow'
 export default function Home() {
     return (
         <main className="h-screen bg-gray-50 p-3 flex flex-col">
-            <div className="max-w-[1600px] mx-auto flex-1 flex flex-col min-h-0">
+            <div className="w-full max-w-[1600px] mx-auto flex-1 flex flex-col min-h-0">
                 <div className="bg-white rounded-lg shadow-sm p-4 flex-1 flex flex-col min-h-0">
                     <VideoGenerationFlow />
                 </div>

--- a/front/src/components/generating/Generating.tsx
+++ b/front/src/components/generating/Generating.tsx
@@ -6,6 +6,9 @@
 export function Generating() {
     return (
         <div className="space-y-4">
+            <div className="flex items-center justify-between mb-3 pb-3 border-b border-gray-200">
+                <h3 className="text-lg font-bold text-gray-800">SUDO<span className="text-xs text-gray-500 ml-5">ー 生成中</span></h3>
+            </div>
             <div className="bg-blue-50 border border-blue-200 rounded-lg p-8 text-center">
                 <div className="flex justify-center mb-4">
                     <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-blue-600" />

--- a/front/src/components/landing/MathTextInput.tsx
+++ b/front/src/components/landing/MathTextInput.tsx
@@ -609,38 +609,10 @@ $$Q(-\\sin\\theta,\\,\\cos\\theta)$$
                             />
                             <p className="mt-2 text-xs text-gray-500">動画の見た目や演出について具体的に指示できます</p>
                         </div>
-
-                        <div className="pt-2">
-                            <button
-                                type="submit"
-                                disabled={!text.trim() || isGenerating}
-                                className="w-full bg-green-600 text-white py-3 px-4 rounded text-base font-semibold hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors shadow-sm flex items-center justify-center gap-2"
-                            >
-                                {isGenerating ? (
-                                    <>
-                                        <svg className="animate-spin h-5 w-5" fill="none" viewBox="0 0 24 24">
-                                            <title>生成中</title>
-                                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                                        </svg>
-                                        動画生成中...
-                                    </>
-                                ) : (
-                                    <>
-                                        動画を生成
-                                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <title>生成</title>
-                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                        </svg>
-                                    </>
-                                )}
-                            </button>
-                        </div>
                     </div>
                     <div className={`lg:col-span-2 flex-col space-y-3 min-h-0 min-w-0 ${isOptionalSettingsOpen ? 'hidden lg:flex' : 'flex'}`}>
                         {/* 表示モード切り替え */}
-                        <div className="flex gap-1 bg-gray-100 p-1 rounded">
+                        <div className="flex gap-1 sm:bg-gray-100 p-1 rounded">
                             {/* Desktop: 3 buttons */}
                             <button
                                 type="button"
@@ -710,16 +682,20 @@ $$Q(-\\sin\\theta,\\,\\cos\\theta)$$
                                 </div>
                             </button>
 
-                            {/* Mobile: Toggle Button */}
+                        </div>
+
+                        {/* ツールバー */}
+                        <div className="flex gap-1.5 sm:gap-2">
+                            {/* Mobile: プレビュー・編集切り替えボタン */}
                             <button
                                 type="button"
                                 onClick={() => setViewMode(viewMode === 'edit' ? 'preview' : 'edit')}
                                 disabled={isGenerating || (viewMode === 'edit' && !text.trim())}
-                                className={`flex sm:hidden w-full px-3 py-2 text-xs font-medium rounded transition-all items-center justify-center gap-1.5 bg-white text-blue-600 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed`}
+                                className="flex sm:hidden flex-1 min-w-0 px-2 py-2 text-xs font-medium bg-white text-gray-700 border border-gray-300 rounded hover:bg-gray-50 hover:border-gray-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors items-center justify-center gap-1"
                             >
                                 {viewMode === 'edit' ? (
                                     <>
-                                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <title>プレビュー</title>
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                                             <path
@@ -729,11 +705,11 @@ $$Q(-\\sin\\theta,\\,\\cos\\theta)$$
                                                 d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
                                             />
                                         </svg>
-                                        <span>プレビュー</span>
+                                        <span className="text-[0.625rem] min-[360px]:text-[0.7rem] truncate">プレビュー</span>
                                     </>
                                 ) : (
                                     <>
-                                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <title>編集</title>
                                             <path
                                                 strokeLinecap="round"
@@ -742,38 +718,35 @@ $$Q(-\\sin\\theta,\\,\\cos\\theta)$$
                                                 d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
                                             />
                                         </svg>
-                                        <span>編集</span>
+                                        <span className="text-[0.625rem] min-[360px]:text-[0.7rem] truncate">編集</span>
                                     </>
                                 )}
                             </button>
-                        </div>
 
-                        {/* ツールバー */}
-                        <div className="flex gap-2">
                             <button
                                 type="button"
                                 onClick={loadSampleText}
                                 disabled={isGenerating}
-                                className="px-3 py-2 text-xs font-medium bg-white text-gray-700 border border-gray-300 rounded hover:bg-gray-50 hover:border-gray-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5"
+                                className="flex-1 min-w-0 px-2 py-2 text-xs font-medium bg-white text-gray-700 border border-gray-300 rounded hover:bg-gray-50 hover:border-gray-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-1"
                             >
-                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <title>サンプル</title>
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                                 </svg>
-                                <span className="text-[0.675rem] min-[330px]:text-xs">サンプルを読み込む</span>
+                                <span className="text-[0.625rem] min-[360px]:text-[0.7rem] sm:text-xs truncate">サンプル</span>
                             </button>
                             <button
                                 type="button"
                                 onClick={handleMathEditorOpen}
                                 disabled={isGenerating || viewMode === 'preview'}
-                                className="px-3 py-2 text-xs font-medium bg-white text-gray-700 border border-gray-300 rounded hover:bg-gray-50 hover:border-gray-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5"
+                                className="flex-1 min-w-0 px-2 py-2 text-xs font-medium bg-white text-gray-700 border border-gray-300 rounded hover:bg-gray-50 hover:border-gray-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-1"
                                 title={viewMode === 'preview' ? 'プレビューモードでは使用できません' : '数式を挿入'}
                             >
-                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <title>数式</title>
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                                 </svg>
-                                <span className="text-[0.675rem] min-[330px]:text-xs">数式を挿入</span>
+                                <span className="text-[0.625rem] min-[360px]:text-[0.7rem] sm:text-xs truncate">数式</span>
                             </button>
                         </div>
 

--- a/front/src/components/landing/MathTextInput.tsx
+++ b/front/src/components/landing/MathTextInput.tsx
@@ -541,7 +541,7 @@ $$Q(-\\sin\\theta,\\,\\cos\\theta)$$
 
                 {/* ヘッダー */}
                 <div className="flex items-center justify-between mb-3 pb-3 border-b border-gray-200">
-                    <h3 className="text-sm font-semibold text-gray-800">数学テキスト入力</h3>
+                    <h3 className="text-lg font-bold text-gray-800">SUDO<span className="text-xs text-gray-500 ml-5">ー 数学テキスト入力</span></h3>
                     {/* モバイル版: オプション設定切替ボタン */}
                     <button
                         type="button"

--- a/front/src/components/landing/MathTextInput.tsx
+++ b/front/src/components/landing/MathTextInput.tsx
@@ -90,6 +90,7 @@ export function MathTextInput({ onSubmit, isGenerating }: MathTextInputProps) {
     const [titleInput, setTitleInput] = useState('')
     const [isGeneratingContent, setIsGeneratingContent] = useState(false)
     const [generationError, setGenerationError] = useState<string | null>(null)
+    const [isOptionalSettingsOpen, setIsOptionalSettingsOpen] = useState(false)
 
     const textAreaRef = useRef<HTMLTextAreaElement>(null)
     const [popupPosition, setPopupPosition] = useState<{ top: number; left: number } | null>(null)
@@ -541,60 +542,209 @@ $$Q(-\\sin\\theta,\\,\\cos\\theta)$$
                 {/* ヘッダー */}
                 <div className="flex items-center justify-between mb-3 pb-3 border-b border-gray-200">
                     <h3 className="text-sm font-semibold text-gray-800">数学テキスト入力</h3>
+                    {/* モバイル版: オプション設定切替ボタン */}
+                    <button
+                        type="button"
+                        onClick={() => setIsOptionalSettingsOpen(!isOptionalSettingsOpen)}
+                        className="lg:hidden px-3 py-1.5 text-xs font-medium bg-gray-100 text-gray-700 border border-gray-300 rounded hover:bg-gray-200 transition-colors flex items-center gap-1.5"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <title>オプション設定</title>
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        </svg>
+                        <span>{isOptionalSettingsOpen ? '閉じる' : 'オプション'}</span>
+                    </button>
                 </div>
 
                 {/* メイン */}
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0 min-w-0">
-                    <div className="lg:col-span-2 flex flex-col space-y-3 min-h-0 min-w-0">
+                    {/* モバイル版: オプション設定表示エリア */}
+                    <div className={`lg:hidden ${isOptionalSettingsOpen ? 'flex' : 'hidden'} flex-col overflow-y-auto space-y-4 pb-4 lg:col-span-1`}>
+                        <div className="bg-gray-50 border border-gray-200 rounded p-4">
+                            <h5 className="text-sm font-medium text-gray-800 mb-3 flex items-center gap-2">
+                                <svg className="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <title>AI</title>
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                                </svg>
+                                AIで文章のひな形を生成
+                            </h5>
+                            <div className="flex flex-col gap-2">
+                                <input
+                                    type="text"
+                                    value={titleInput}
+                                    onChange={(e) => setTitleInput(e.target.value)}
+                                    placeholder="例: 積分の方法、微分の公式"
+                                    className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                    disabled={isGeneratingContent || isGenerating}
+                                />
+                                <button
+                                    type="button"
+                                    onClick={handleGenerateFromTitle}
+                                    disabled={!titleInput.trim() || isGeneratingContent || isGenerating}
+                                    className="w-full px-4 py-2 text-sm font-medium text-white bg-gray-700 rounded hover:bg-gray-800 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                                >
+                                    {isGeneratingContent ? '生成中...' : '生成'}
+                                </button>
+                            </div>
+                            {generationError && <p className="mt-2 text-xs text-red-600">{generationError}</p>}
+                            <p className="mt-2 text-xs text-gray-600">トピックのタイトルを入力すると、Markdown + LaTeX形式の解説を生成します</p>
+                        </div>
+
+                        <div className="bg-gray-50 border border-gray-200 rounded p-4">
+                            <h5 className="text-sm font-medium text-gray-800 mb-3 flex items-center gap-2">
+                                <svg className="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <title>動画</title>
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                </svg>
+                                動画への追加指示（任意）
+                            </h5>
+                            <textarea
+                                id="video-prompt-mobile"
+                                value={videoPrompt}
+                                onChange={(e) => setVideoPrompt(e.target.value)}
+                                placeholder="例: 積分記号を赤色で強調、文字サイズを大きく"
+                                className="w-full p-3 text-sm border border-gray-300 rounded h-32 focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+                                disabled={isGenerating}
+                            />
+                            <p className="mt-2 text-xs text-gray-500">動画の見た目や演出について具体的に指示できます</p>
+                        </div>
+
+                        <div className="pt-2">
+                            <button
+                                type="submit"
+                                disabled={!text.trim() || isGenerating}
+                                className="w-full bg-green-600 text-white py-3 px-4 rounded text-base font-semibold hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors shadow-sm flex items-center justify-center gap-2"
+                            >
+                                {isGenerating ? (
+                                    <>
+                                        <svg className="animate-spin h-5 w-5" fill="none" viewBox="0 0 24 24">
+                                            <title>生成中</title>
+                                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                                        </svg>
+                                        動画生成中...
+                                    </>
+                                ) : (
+                                    <>
+                                        動画を生成
+                                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <title>生成</title>
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                        </svg>
+                                    </>
+                                )}
+                            </button>
+                        </div>
+                    </div>
+                    <div className={`lg:col-span-2 flex-col space-y-3 min-h-0 min-w-0 ${isOptionalSettingsOpen ? 'hidden lg:flex' : 'flex'}`}>
                         {/* 表示モード切り替え */}
                         <div className="flex gap-1 bg-gray-100 p-1 rounded">
+                            {/* Desktop: 3 buttons */}
                             <button
                                 type="button"
                                 onClick={() => setViewMode('edit')}
                                 disabled={isGenerating}
-                                className={`px-3 py-2 text-xs font-medium rounded transition-all flex items-center gap-1.5 ${viewMode === 'edit' ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-600 hover:text-gray-900'
-                                    } disabled:opacity-50 disabled:cursor-not-allowed`}
+                                className={`hidden sm:flex px-3 py-2 text-xs font-medium rounded transition-all items-center gap-1.5 ${
+                                    viewMode === 'edit' ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-600 hover:text-gray-900'
+                                } disabled:opacity-50 disabled:cursor-not-allowed`}
                             >
                                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <title>編集</title>
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                                    />
                                 </svg>
                                 <div className="flex flex-col sm:flex-row">
-                                    <span className="text-xxs min-[360px]:text-xs">編集</span><span className="text-xxs min-[360px]:text-xs">のみ</span>
+                                    <span className="text-xxs min-[360px]:text-xs">編集</span>
+                                    <span className="text-xxs min-[360px]:text-xs">のみ</span>
                                 </div>
                             </button>
                             <button
                                 type="button"
                                 onClick={() => setViewMode('split')}
                                 disabled={isGenerating || !text.trim()}
-                                className={`px-3 py-2 text-xs font-medium rounded transition-all flex items-center gap-1.5 ${viewMode === 'split' ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-600 hover:text-gray-900'
-                                    } disabled:opacity-50 disabled:cursor-not-allowed`}
+                                className={`hidden sm:flex px-3 py-2 text-xs font-medium rounded transition-all items-center gap-1.5 ${
+                                    viewMode === 'split' ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-600 hover:text-gray-900'
+                                } disabled:opacity-50 disabled:cursor-not-allowed`}
                             >
                                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <title>分割</title>
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7" />
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7"
+                                    />
                                 </svg>
-                                
                                 <div className="flex flex-col sm:flex-row">
-                                    <span className="text-xxs min-[360px]:text-xs">編集+</span><span className="text-xxs min-[360px]:text-xs">プレビュー</span>
+                                    <span className="text-xxs min-[360px]:text-xs">編集+</span>
+                                    <span className="text-xxs min-[360px]:text-xs">プレビュー</span>
                                 </div>
                             </button>
                             <button
                                 type="button"
                                 onClick={() => setViewMode('preview')}
                                 disabled={isGenerating || !text.trim()}
-                                className={`px-3 py-2 text-xs font-medium rounded transition-all flex items-center gap-1.5 ${viewMode === 'preview' ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-600 hover:text-gray-900'
-                                    } disabled:opacity-50 disabled:cursor-not-allowed`}
+                                className={`hidden sm:flex px-3 py-2 text-xs font-medium rounded transition-all items-center gap-1.5 ${
+                                    viewMode === 'preview' ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-600 hover:text-gray-900'
+                                } disabled:opacity-50 disabled:cursor-not-allowed`}
                             >
                                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <title>プレビュー</title>
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                                    />
                                 </svg>
                                 <div className="flex flex-col sm:flex-row">
-                                    <span className="text-xxs min-[360px]:text-xs">プレビュー</span><span className="text-xxs min-[360px]:text-xs">のみ</span>
+                                    <span className="text-xxs min-[360px]:text-xs">プレビュー</span>
+                                    <span className="text-xxs min-[360px]:text-xs">のみ</span>
                                 </div>
-                                
+                            </button>
+
+                            {/* Mobile: Toggle Button */}
+                            <button
+                                type="button"
+                                onClick={() => setViewMode(viewMode === 'edit' ? 'preview' : 'edit')}
+                                disabled={isGenerating || (viewMode === 'edit' && !text.trim())}
+                                className={`flex sm:hidden w-full px-3 py-2 text-xs font-medium rounded transition-all items-center justify-center gap-1.5 bg-white text-blue-600 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed`}
+                            >
+                                {viewMode === 'edit' ? (
+                                    <>
+                                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <title>プレビュー</title>
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                            <path
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                                strokeWidth={2}
+                                                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                                            />
+                                        </svg>
+                                        <span>プレビュー</span>
+                                    </>
+                                ) : (
+                                    <>
+                                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <title>編集</title>
+                                            <path
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                                strokeWidth={2}
+                                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                                            />
+                                        </svg>
+                                        <span>編集</span>
+                                    </>
+                                )}
                             </button>
                         </div>
 
@@ -681,9 +831,9 @@ $$Q(-\\sin\\theta,\\,\\cos\\theta)$$
                     {/* 右側: 操作エリア */}
                     <div className="flex flex-col min-h-0 min-w-0">
                         <div className="overflow-y-auto flex-1 min-h-0 pr-2">
-                            <div className="space-y-3">
-                                {/* AIで文章のひな形を生成 */}
-                                <div className="bg-gray-50 border border-gray-200 rounded p-3">
+                            <div className="flex flex-col gap-4 lg:block lg:space-y-3">
+                                {/* デスクトップ版: 通常表示 */}
+                                <div className="hidden lg:block order-1 bg-gray-50 border border-gray-200 rounded p-3">
                                     <h5 className="text-sm font-medium text-gray-800 mb-2 flex items-center gap-2">
                                         <svg className="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <title>AI</title>
@@ -712,9 +862,7 @@ $$Q(-\\sin\\theta,\\,\\cos\\theta)$$
                                     {generationError && <p className="mt-2 text-xs text-red-600">{generationError}</p>}
                                     <p className="mt-2 text-xs text-gray-600">トピックのタイトルを入力すると、Markdown + LaTeX形式の解説を生成します</p>
                                 </div>
-
-                                {/* 動画への追加指示 */}
-                                <div className="bg-gray-50 border border-gray-200 rounded p-3">
+                                <div className="hidden lg:block order-2 bg-gray-50 border border-gray-200 rounded p-3">
                                     <h5 className="text-sm font-medium text-gray-800 mb-2 flex items-center gap-2">
                                         <svg className="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <title>動画</title>
@@ -734,7 +882,7 @@ $$Q(-\\sin\\theta,\\,\\cos\\theta)$$
                                 </div>
 
                                 {/* 動画生成ボタン */}
-                                <div className="pt-3 border-t border-gray-200">
+                                <div className="order-1 lg:order-3 lg:pt-3 lg:border-t border-gray-200">
                                     <button
                                         type="submit"
                                         disabled={!text.trim() || isGenerating}

--- a/front/src/components/landing/MathTextInput.tsx
+++ b/front/src/components/landing/MathTextInput.tsx
@@ -542,24 +542,24 @@ $$Q(-\\sin\\theta,\\,\\cos\\theta)$$
                 {/* ヘッダー */}
                 <div className="flex items-center justify-between mb-3 pb-3 border-b border-gray-200">
                     <h3 className="text-lg font-bold text-gray-800">SUDO<span className="text-xs text-gray-500 ml-5">ー 数学テキスト入力</span></h3>
-                    {/* モバイル版: オプション設定切替ボタン */}
+                    {/* モバイル版: 追加項目設定切替ボタン */}
                     <button
                         type="button"
                         onClick={() => setIsOptionalSettingsOpen(!isOptionalSettingsOpen)}
                         className="lg:hidden px-3 py-1.5 text-xs font-medium bg-gray-100 text-gray-700 border border-gray-300 rounded hover:bg-gray-200 transition-colors flex items-center gap-1.5"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <title>オプション設定</title>
+                            <title>追加項目設定</title>
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                         </svg>
-                        <span>{isOptionalSettingsOpen ? '閉じる' : 'オプション'}</span>
+                        <span>{isOptionalSettingsOpen ? '閉じる' : '追加項目'}</span>
                     </button>
                 </div>
 
                 {/* メイン */}
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0 min-w-0">
-                    {/* モバイル版: オプション設定表示エリア */}
+                    {/* モバイル版: 追加項目設定表示エリア */}
                     <div className={`lg:hidden ${isOptionalSettingsOpen ? 'flex' : 'hidden'} flex-col overflow-y-auto space-y-4 pb-4 lg:col-span-1`}>
                         <div className="bg-gray-50 border border-gray-200 rounded p-4">
                             <h5 className="text-sm font-medium text-gray-800 mb-3 flex items-center gap-2">

--- a/front/src/components/prompt/PromptEditor.tsx
+++ b/front/src/components/prompt/PromptEditor.tsx
@@ -30,7 +30,7 @@ export function PromptEditor({ prompt, isGenerating, onGenerate }: PromptEditorP
         <div className="flex flex-col h-full min-w-0 w-full">
             {/* ヘッダー */}
             <div className="flex items-center justify-between mb-2 pb-2 border-b border-gray-200">
-                <h3 className="text-sm font-semibold text-gray-800">プロンプト確認・編集</h3>
+                <h3 className="text-lg font-bold text-gray-800">SUDO<span className="text-xs text-gray-500 ml-5">ー プロンプト確認・編集</span></h3>
             </div>
 
             {/* メインコンテンツ: 2カラムレイアウト（右は常に固定幅） */}

--- a/front/src/components/result/Result.tsx
+++ b/front/src/components/result/Result.tsx
@@ -58,7 +58,7 @@ export function Result({ result, isGenerating, onEdit, onReset }: ResultProps) {
             </div>
 
             {/* メインコンテンツ: 2カラムレイアウト */}
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 flex-1 min-h-0 min-w-0">
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 sm:flex-1 min-h-0 min-w-0">
                 {/* 左側: 動画プレイヤー（メイン） */}
                 <div className="lg:col-span-2 flex flex-col min-h-0 min-w-0 w-full gap-2">
                     <VideoPlayer videoUrl={result.videoUrl} />

--- a/front/src/components/result/Result.tsx
+++ b/front/src/components/result/Result.tsx
@@ -38,8 +38,8 @@ export function Result({ result, isGenerating, onEdit, onReset }: ResultProps) {
     return (
         <div className="flex flex-col h-full">
             {/* ヘッダー */}
-            <div className="flex items-center justify-between mb-3">
-                <h2 className="text-lg font-semibold text-gray-800">動画生成完了</h2>
+            <div className="flex items-center justify-between mb-3 pb-3 border-b border-gray-200">
+                <h3 className="text-lg font-bold text-gray-800">SUDO<span className="text-xs text-gray-500 ml-5">ー 数学テキスト入力</span></h3>
                 {onReset && (
                     <button
                         type="button"

--- a/front/src/components/result/VideoEditDialog.tsx
+++ b/front/src/components/result/VideoEditDialog.tsx
@@ -44,7 +44,7 @@ export function VideoEditDialog({
             {isOpen && (
                 <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
                     <div className="bg-white rounded-lg p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-                        <h3 className="text-xl font-bold text-gray-800 mb-4">動画を編集</h3>
+                        <h3 className="text-lg font-bold text-gray-800">SUDO<span className="text-xs text-gray-500 ml-5">ー 動画を編集</span></h3>
                         <p className="text-sm text-gray-600 mb-4">
                             動画の不具合や改善点を説明してください
                         </p>


### PR DESCRIPTION
## issue番号（- #〇）
切ってないです
## やったこと（動作の確認のため、ある場合は動画や画像を添付してください）
今回用いている4画面について、スマホの操作に最適な構造となるように再構築しました。

1. Landingページ
<video src="https://github.com/user-attachments/assets/b11512aa-93a0-4990-b2b0-d6fa26947561"></video>
<video src="https://github.com/user-attachments/assets/930f88dd-5dac-4d3f-a56e-4872014cc247"></video>

入力欄が最もユーザが触れるエリアであるため、それが消えていた以前の実装から、以下の点を改善しています。
・プレビュー・編集モードは、画面幅を侵食してしまう上スマホユーザが望んでいるものではないと考えたため、これを削除し、ワンクリックで編集とプレビューを切り替えられるようにしました。
・ＡＩひな型、追加オプションはすべて「オプションボタン」に格納し、オプションボタンを押下している間は入力欄が操作できないようにしました。これによりユーザが何をすればいいのかが明確になります。

2. Generationページ
<video src="https://github.com/user-attachments/assets/d16fbdf4-c8d6-4dd3-9258-c25f9be84038"></video>

こちらの画面は、レスポンシブ対応に係る隙間の発生があったので、それを修正するにとどまっています。

3. （全ページ共通）
<img width="683" height="427" alt="image" src="https://github.com/user-attachments/assets/9207fc85-1f9c-43b1-a3af-2921c38c447c" />

以前話していた、ヘッダーにおいて現在位置を理解できるようにする処理を追加し、それに伴って各ページで統一されていなかったmargin等を統一しました。


## とくに見て欲しいところ
・[d922f4b](https://github.com/jphacks/ng_2501/pull/70/commits/d922f4b0afc6357ea3a59b7b06a5e0664e5c779e)にてやった処理は、オプションボタンを押したときに、横幅が広がってしまう問題に対処する処理です。全ページにおいて、デザインの崩壊は生じていないことを確認しています。

・[8b050bf](https://github.com/jphacks/ng_2501/pull/70/commits/8b050bff30eb212ca470461ea6fe1245ea76829d)における処理は暫定です。本来はSUDOの文字欄にロゴが入る想定です！

## 不安なところ
議論していたヘッダーのラフを踏まえて、現在位置を薄い灰色で表示するという処理にしましたが、まだこれが適切かは測りかねている...

## その他情報（別で取った議事録等、このプルリクに関連する情報があれば）
デザインの再考について議論したスレッドです：https://discord.com/channels/1420354588388753410/1433318047636131911

---
<details>
  <summary>ブランチ名について</summary>

以下のいずれかをブランチの先頭につけてブランチを命名してください

- `feature/` 機能改修
- `bugfix/` バグ修正
- `refactor/` リファクタリング
- `deps/` 依存パッケージなどのアップデート
- `chore/` 雑用、当てはまるラベルがないときに設定する

例: `feature/login-button`

</details>

<details>
  <summary>reviewer・mergeについて</summary>

for 作業者：
- レビュー担当者には、ジャンルに分けて以下の人を任命する：
	- フロントエンド(デザイン)：**みつを**　まこちゃーん
  - フロントエンド(ロジック)：**まこちゃーん**　めろ
  - バックエンド(AIエージェント/RAG)：**やづや**（精度)　めろ(速度）
  - バックエンド(API・DBなどその他)：**まこちゃーん** やづや
  - ロゴ/スライドその他：みつを まこちゃーん めろ
  - インフラ（CI/CD)：やづや
- レビューが承認(Approve)されたらmergeする
- レビューが非承認なら再度作業してpushし、コメントでコミット番号を明示しレビュー担当をメンションする

for レビュワー：
- レビュー担当はレビューをしたらDiscordにそれを通知する
- レビューは、わからないことへの共通認識をつけることを目的として、とにかく質問する。質問が無ければOK
- フロントエンドについては、実際に依頼された人が成果物を動作させて確認する

※ 作業の担当外の人は勉強になったことなどをコメントできるとBetterです!
</details>
<details>
  <summary>レビューのコメントについて</summary>

レビュー時はバッヂ（テキストでも可）を付けて、どのレベル感のコメントか明示します。

- ![badge](https://img.shields.io/badge/review-must-red.svg) `[must]` 必ず直すべき
- ![badge](https://img.shields.io/badge/review-imo-orange.svg) `[imo]` 自分の考えは〜
- ![badge](https://img.shields.io/badge/review-nits-green.svg) `[nit]`細かい指摘
- ![badge](https://img.shields.io/badge/review-ask-blue.svg) `[ask]` 質問/確認
- ![badge](https://img.shields.io/badge/review-fyi-yellow.svg) `[fyi]` ご参考まで

例

md
![badge](https://img.shields.io/badge/review-fyi-yellow.svg)

また、基本的に担当者がわからないことを質問することをレビューとします。フロントエンドについては、実際に成果物を触ってチェックするウォークスルーレビューを行います。
</details>
